### PR TITLE
fix: throw actual error in oauth

### DIFF
--- a/src/auth/strategies/OAuthTenantStrategy.ts
+++ b/src/auth/strategies/OAuthTenantStrategy.ts
@@ -5,6 +5,7 @@ import qs from 'qs';
 
 export default class OAuthTenantStrategy extends OAuthStrategy {
 	async getEntityQuery(profile: OAuthProfile, params: Params) {
+		if (profile?.error)	throw new Error(profile.error);
 		if (!profile.email || !params?.query?.tenantId) throw new Error('Missing paramenter(s)');
 
 		return {


### PR DESCRIPTION
This PR will make oauth debugging easier.

Before, we always get "Missing parameters" no matter what the error was.
Now we will get the actual error from the profile argument, like so:

```
info: Feathers app listening on http://localhost:3030
error: Error: self-signed certificate
    at OAuthTenantStrategy.getEntityQuery (/home/pontus/Edumeet/edumeet-management-server/dist/src/auth/strategies/OAuthTenantStrategy.js:11:19)
    at OAuthTenantStrategy.findEntity (/home/pontus/Edumeet/edumeet-management-server/node_modules/@feathersjs/authentication-oauth/lib/strategy.js:79:34)
    at OAuthTenantStrategy.authenticate (/home/pontus/Edumeet/edumeet-management-server/node_modules/@feathersjs/authentication-oauth/lib/strategy.js:118:44)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```