### PR TITLE
Add default state and nonce for OAuth configuration

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -35,6 +35,10 @@
 			"passwordField": "password"
 		},
 		"oauth": {
+			"defaults": {
+				"state": true,
+				"nonce": true
+            },
 			"tenant": {
 				"oauth": 2,
 				"dynamic": [ "key", "secret", "authorize_url", "access_url", "profile_url", "scope_delimiter", "scope", "redirect_uri" ]


### PR DESCRIPTION
enables explicit state & nonce in OAuth configuration

- Add `state: true` and `nonce: true` for each OAuth provider in the Feathers authentication config.
- Aligns the application with Feathers OAuth defaults that toggle random `state` and `nonce` generation per provider, ensuring the security‑critical parameters are always active.
- Improves overall security posture and brings the implementation into compliance with IETF best‑current‑practice recommendations for OAuth 2.0 and OpenID Connect.

Refs:
1. https://github.com/simov/grant#configuration-description
2. https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
3. https://datatracker.ietf.org/doc/html/rfc6819#section-5.3.5
4. https://datatracker.ietf.org/doc/html/rfc9700.html#name-nonce